### PR TITLE
Simplify Travis CI setup and parts of Python tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,79 +1,50 @@
-language: c
-os: linux
-dist: trusty
-sudo: required
-compiler: gcc
-cache:
-  apt: true
-  pip: true
-  directories:
-    - $HOME/.cache/pip
-    - $HOME/.local
-      
+dist: xenial
+language: python
+python: "3.7"
+cache: pip
+
 matrix:
   include:
-    - env: CVER=gfortran4
-      language: c
+    - env: FC=gfortran-4.9
       addons:
         apt:
-          sources: 
-            - ubuntu-toolchain-r-test
-          packages: 
+          sources: ubuntu-toolchain-r-test
+          packages:
             - gfortran-4.9
-            - dpkg
-            - unzip
 
-    - env: CVER=gfortran5
-      language: c
+    - env: FC=gfortran-5
       addons:
         apt:
-          sources: 
-            - ubuntu-toolchain-r-test
-          packages: 
+          sources: ubuntu-toolchain-r-test
+          packages:
             - gfortran-5
-            - dpkg
-            - unzip
 
-    - env: CVER=gfortran6
-      language: c
+    - env: FC=gfortran-6
       addons:
         apt:
-          sources: 
-            - ubuntu-toolchain-r-test
-          packages: 
+          sources: ubuntu-toolchain-r-test
+          packages:
             - gfortran-6
-            - dpkg
-            - unzip
 
-    - env: CVER=gfortran7
-      language: c
+    - env: FC=gfortran-7
       addons:
         apt:
-          sources: 
-            - ubuntu-toolchain-r-test
-          packages: 
+          sources: ubuntu-toolchain-r-test
+          packages:
             - gfortran-7
-            - dpkg
-            - unzip
 
-    - env: CVER=gfortran8
-      language: c
+    - env: FC=gfortran-8
       addons:
         apt:
-          sources: 
-            - ubuntu-toolchain-r-test
-          packages: 
+          sources: ubuntu-toolchain-r-test
+          packages:
             - gfortran-8
-            - dpkg
-            - unzip
-     
+
   # allowed failures - uncomment lines below to allow failure
   #                    of specific gfortran compilers
   #allow_failures:
-  #  - env: CVER=gfortran7
-  #  - env: CVER=gfortran8
-     
-
+  #  - env: FC=gfortran-7
+  #  - env: FC=gfortran-8
 
 
 install:
@@ -81,48 +52,11 @@ install:
         mkdir "$HOME/.local/bin";
       fi
     - export PATH="$HOME/.local/bin:$PATH"
-    - if [[ $CVER == "gfortran4" ]]; then
-        ln -fs /usr/bin/gfortran-4.9 "$HOME/.local/bin/gfortran";
-        gfortran --version;
-        ls -l /usr/bin/gfortran-4.9;
-      fi
-    - if [[ $CVER == "gfortran5" ]]; then
-        ln -fs /usr/bin/gfortran-5 "$HOME/.local/bin/gfortran";
-        gfortran --version;
-        ls -l /usr/bin/gfortran-5;
-      fi
-    - if [[ $CVER == "gfortran6" ]]; then
-        ln -fs /usr/bin/gfortran-6 "$HOME/.local/bin/gfortran";
-        gfortran --version;
-        ls -l /usr/bin/gfortran-6;
-      fi
-    - if [[ $CVER == "gfortran7" ]]; then
-        ln -fs /usr/bin/gfortran-7 "$HOME/.local/bin/gfortran";
-        gfortran --version;
-        ls -l /usr/bin/gfortran-7;
-      fi
-    - if [[ $CVER == "gfortran8" ]]; then
-        ln -fs /usr/bin/gfortran-8 "$HOME/.local/bin/gfortran";
-        gfortran --version;
-        ls -l /usr/bin/gfortran-8;
-      fi
-    # install anaconda
-    - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-      fi
-    - bash miniconda.sh -b -p $HOME/miniconda
-    - export PATH="$HOME/miniconda/bin:$PATH"
-    - hash -r
-    - conda config --set always_yes yes --set changeps1 no
-    - conda update -q conda
-    # Useful for debugging any issues with conda
-    - conda info -a
-    - conda install nose
-    - python --version
-    - pip install numpy
+    - ln -fs /usr/bin/$FC "$HOME/.local/bin/gfortran"
+    - gfortran --version
+    - pip install nose-timer requests numpy matplotlib
     - pip install https://github.com/modflowpy/flopy/zipball/develop
     - pip install https://github.com/modflowpy/pymake/zipball/master
-    - pip install nose-timer
 
 
 script:

--- a/autotest/t003_test.py
+++ b/autotest/t003_test.py
@@ -62,8 +62,8 @@ def run_mt3d(spth, comparison=True):
         # needs to be inserted into the linker file for simulating
         # a period of equilibration.
         print('running insert_stopflow_period.py...{}'.format(testname))
-        insert_stopflow_period.InsStpFlw()
-        
+        insert_stopflow_period.InsStpFlw(testpth)
+
         print('running mt3d-usgs model...{}'.format(testname))
         nam = os.path.basename(mtnamefile)
         exe_name = os.path.abspath(config.target)

--- a/autotest/t004_test_mt3dms_p01.py
+++ b/autotest/t004_test_mt3dms_p01.py
@@ -143,8 +143,7 @@ def test_mt3dmsp01a():
                                             retardation, zero_order_decay,
                                             mixelm, zeta, prsity2)
 
-    msg = 'concentrations not equal {} {}'.format(conc_mt3dusgs, conc_mt3dms)
-    assert  np.allclose(conc_mt3dusgs, conc_mt3dms, atol=1e-4), msg
+    np.testing.assert_allclose(conc_mt3dusgs, conc_mt3dms, atol=1e-4)
     return
 
 
@@ -169,8 +168,7 @@ def test_mt3dmsp01b():
                                             retardation, zero_order_decay,
                                             mixelm, zeta, prsity2)
 
-    msg = 'concentrations not equal {} {}'.format(conc_mt3dusgs, conc_mt3dms)
-    assert  np.allclose(conc_mt3dusgs, conc_mt3dms, atol=1e-4), msg
+    np.testing.assert_allclose(conc_mt3dusgs, conc_mt3dms, atol=1e-4)
     return
 
 
@@ -195,8 +193,7 @@ def test_mt3dmsp01c():
                                             retardation, zero_order_decay,
                                             mixelm, zeta, prsity2)
 
-    msg = 'concentrations not equal {} {}'.format(conc_mt3dusgs, conc_mt3dms)
-    assert  np.allclose(conc_mt3dusgs, conc_mt3dms, atol=1e-4), msg
+    np.testing.assert_allclose(conc_mt3dusgs, conc_mt3dms, atol=1e-4)
     return
 
 
@@ -221,8 +218,7 @@ def test_mt3dmsp01d():
                                             retardation, zero_order_decay,
                                             mixelm, zeta, prsity2)
 
-    msg = 'concentrations not equal {} {}'.format(conc_mt3dusgs, conc_mt3dms)
-    assert  np.allclose(conc_mt3dusgs, conc_mt3dms, atol=1e-4), msg
+    np.testing.assert_allclose(conc_mt3dusgs, conc_mt3dms, atol=1e-4)
     return
 
 
@@ -247,8 +243,7 @@ def test_mt3dmsp01e():
                                             retardation, zero_order_decay,
                                             mixelm, zeta, prsity2)
 
-    msg = 'concentrations not equal {} {}'.format(conc_mt3dusgs, conc_mt3dms)
-    assert  np.allclose(conc_mt3dusgs, conc_mt3dms, atol=1e-4), msg
+    np.testing.assert_allclose(conc_mt3dusgs, conc_mt3dms, atol=1e-4)
     return
 
 

--- a/autotest/t005_test_mt3dms_p02.py
+++ b/autotest/t005_test_mt3dms_p02.py
@@ -130,8 +130,7 @@ def test_mt3dmsp02a():  # Tests Freudlich
                                             mt3dms_ws, isothm,
                                             sp1, sp2, mixelm, zeta)
 
-    msg = 'concentrations not equal {} {}'.format(conc_mt3dusgs, conc_mt3dms)
-    assert  np.allclose(conc_mt3dusgs, conc_mt3dms, atol=1e-4), msg
+    np.testing.assert_allclose(conc_mt3dusgs, conc_mt3dms, atol=1e-4)
     return
 
 
@@ -153,8 +152,7 @@ def test_mt3dmsp02b():  # Tests Langmuir
                                             mt3dms_ws, isothm,
                                             sp1, sp2, mixelm, zeta)
 
-    msg = 'concentrations not equal {} {}'.format(conc_mt3dusgs, conc_mt3dms)
-    assert np.allclose(conc_mt3dusgs, conc_mt3dms, atol=1e-4), msg
+    np.testing.assert_allclose(conc_mt3dusgs, conc_mt3dms, atol=1e-4)
     return
 
 def test_mt3dmsp02c():  # Tests Nonequilibrium
@@ -176,8 +174,9 @@ def test_mt3dmsp02c():  # Tests Nonequilibrium
                                                 mt3dms_ws, isothm,
                                                 sp1, beta, mixelm, zeta)
 
-        msg = 'concentrations not equal {} {} for beta {}'.format(conc_mt3dusgs, conc_mt3dms, str(beta))
-        assert np.allclose(conc_mt3dusgs, conc_mt3dms, atol=1e-4), msg
+        msg = 'concentrations not equal for beta {}'.format(beta)
+        np.testing.assert_allclose(conc_mt3dusgs, conc_mt3dms, atol=1e-4,
+                                   err_msg=msg)
 
     return
 

--- a/autotest/t006_test_mt3dms_p03.py
+++ b/autotest/t006_test_mt3dms_p03.py
@@ -124,8 +124,7 @@ def test_mt3dmsp03a():
     mf, mt, conc_mt3dms, cvt, mvt = p03mt3d(exe_name_mf, exe_name_mt3dms,
                                             mt3dms_ws, mixelm)
 
-    msg = 'concentrations not equal {} {}'.format(conc_mt3dusgs, conc_mt3dms)
-    assert  np.allclose(conc_mt3dusgs, conc_mt3dms, atol=1e-4), msg
+    np.testing.assert_allclose(conc_mt3dusgs, conc_mt3dms, atol=1e-4)
     return
 
 
@@ -141,8 +140,7 @@ def test_mt3dmsp03b():  # Tests Langmuir
     mf, mt, conc_mt3dms, cvt, mvt = p03mt3d(exe_name_mf, exe_name_mt3dms,
                                             mt3dms_ws, mixelm)
 
-    msg = 'concentrations not equal {} {}'.format(conc_mt3dusgs, conc_mt3dms)
-    assert np.allclose(conc_mt3dusgs, conc_mt3dms, atol=1e-4), msg
+    np.testing.assert_allclose(conc_mt3dusgs, conc_mt3dms, atol=1e-4)
     return
 
 

--- a/autotest/t007_test_mt3dms_p04.py
+++ b/autotest/t007_test_mt3dms_p04.py
@@ -133,8 +133,7 @@ def test_mt3dmsp04a():
     mf, mt, conc_mt3dms, cvt, mvt = p04mt3d(exe_name_mf, exe_name_mt3dms,
                                             mt3dms_ws, mixelm)
 
-    msg = 'concentrations not equal {} {}'.format(conc_mt3dusgs, conc_mt3dms)
-    assert  np.allclose(conc_mt3dusgs, conc_mt3dms, atol=6.0e-4), msg
+    np.testing.assert_allclose(conc_mt3dusgs, conc_mt3dms, atol=6.0e-4)
     return
 
 
@@ -150,8 +149,7 @@ def test_mt3dmsp04b():
     mf, mt, conc_mt3dms, cvt, mvt = p04mt3d(exe_name_mf, exe_name_mt3dms,
                                             mt3dms_ws, mixelm)
 
-    msg = 'concentrations not equal {} {}'.format(conc_mt3dusgs, conc_mt3dms)
-    assert np.allclose(conc_mt3dusgs, conc_mt3dms, atol=1e-4), msg
+    np.testing.assert_allclose(conc_mt3dusgs, conc_mt3dms, atol=1e-4)
     return
 
 
@@ -166,8 +164,7 @@ def test_mt3dmsp04c():
     mf, mt, conc_mt3dms, cvt, mvt = p04mt3d(exe_name_mf, exe_name_mt3dms,
                                             mt3dms_ws, mixelm)
 
-    msg = 'concentrations not equal {} {}'.format(conc_mt3dusgs, conc_mt3dms)
-    assert np.allclose(conc_mt3dusgs, conc_mt3dms, atol=1e-4), msg
+    np.testing.assert_allclose(conc_mt3dusgs, conc_mt3dms, atol=1e-4)
     return
 
 

--- a/autotest/t008_test_mt3dms_p05.py
+++ b/autotest/t008_test_mt3dms_p05.py
@@ -123,8 +123,7 @@ def test_mt3dmsp05a():
     mf, mt, conc_mt3dms, cvt, mvt = p05mt3d(exe_name_mf, exe_name_mt3dms,
                                             mt3dms_ws, mixelm, dt0, ttsmult)
 
-    msg = 'concentrations not equal {} {}'.format(conc_mt3dusgs, conc_mt3dms)
-    assert  np.allclose(conc_mt3dusgs, conc_mt3dms, atol=1.0e-4), msg
+    np.testing.assert_allclose(conc_mt3dusgs, conc_mt3dms, atol=1.0e-4)
     return
 
 

--- a/autotest/t009_test_mt3dms_p06.py
+++ b/autotest/t009_test_mt3dms_p06.py
@@ -124,8 +124,8 @@ def test_mt3dmsp06a():
     mf, mt, conc_mt3dms, cvt, mvt = p06mt3d(exe_name_mf, exe_name_mt3dms,
                                             mt3dms_ws, mixelm, dt0)
 
-    msg = 'concentrations not equal {} {}'.format(conc_mt3dusgs, conc_mt3dms)
-    assert  np.allclose(conc_mt3dusgs, conc_mt3dms, atol=1.0e-4), msg
+    np.testing.assert_allclose(conc_mt3dusgs, conc_mt3dms,
+                               rtol=1e-05, atol=1.0e-4)
     return
 
 
@@ -143,8 +143,8 @@ def test_mt3dmsp06b():
     mf, mt, conc_mt3dms, cvt, mvt = p06mt3d(exe_name_mf, exe_name_mt3dms,
                                             mt3dms_ws, mixelm, dt0)
 
-    msg = 'concentrations not equal {} {}'.format(conc_mt3dusgs, conc_mt3dms)
-    assert  np.allclose(conc_mt3dusgs, conc_mt3dms, atol=1.0e-4), msg
+    np.testing.assert_allclose(conc_mt3dusgs, conc_mt3dms,
+                               rtol=1e-05, atol=1.0e-4)
     return
 
 
@@ -162,8 +162,8 @@ def test_mt3dmsp06c():
     mf, mt, conc_mt3dms, cvt, mvt = p06mt3d(exe_name_mf, exe_name_mt3dms,
                                             mt3dms_ws, mixelm, dt0)
 
-    msg = 'concentrations not equal {} {}'.format(conc_mt3dusgs, conc_mt3dms)
-    assert  np.allclose(conc_mt3dusgs, conc_mt3dms, atol=1.0e-4), msg
+    np.testing.assert_allclose(conc_mt3dusgs, conc_mt3dms,
+                               rtol=1e-05, atol=1.0e-4)
     return
 
 

--- a/autotest/t010_test_mt3dms_p07.py
+++ b/autotest/t010_test_mt3dms_p07.py
@@ -125,8 +125,7 @@ def test_mt3dmsp07a():
     mf, mt, conc_mt3dms, cvt, mvt = p07mt3d(exe_name_mf, exe_name_mt3dms,
                                             mt3dms_ws, mixelm)
 
-    msg = 'concentrations not equal {} {}'.format(conc_mt3dusgs, conc_mt3dms)
-    assert  np.allclose(conc_mt3dusgs, conc_mt3dms, atol=1.0e-4), msg
+    np.testing.assert_allclose(conc_mt3dusgs, conc_mt3dms, atol=1.0e-4)
     return
 
 

--- a/autotest/t011_crashes_tst_mt3dms_p08.py
+++ b/autotest/t011_crashes_tst_mt3dms_p08.py
@@ -140,8 +140,7 @@ def test_mt3dmsp08a():
     mf, mt, conc_mt3dms, cvt, mvt = p08mt3d(exe_name_mf, exe_name_mt3dms,
                                             mt3dms_ws, mixelm)
 
-    msg = 'concentrations not equal {} {}'.format(conc_mt3dusgs, conc_mt3dms)
-    assert  np.allclose(conc_mt3dusgs, conc_mt3dms, atol=1.0e-4), msg
+    np.testing.assert_allclose(conc_mt3dusgs, conc_mt3dms, atol=1.0e-4)
     return
 
 

--- a/autotest/t012_test_mt3dms_p09.py
+++ b/autotest/t012_test_mt3dms_p09.py
@@ -131,8 +131,7 @@ def test_mt3dmsp09a():
     mf, mt, conc_mt3dms, cvt, mvt = p09mt3d(exe_name_mf, exe_name_mt3dms,
                                             mt3dms_ws, mixelm, nadvfd)
 
-    msg = 'concentrations not equal {} {}'.format(conc_mt3dusgs, conc_mt3dms)
-    assert  np.allclose(conc_mt3dusgs, conc_mt3dms, atol=1.5e-3), msg
+    np.testing.assert_allclose(conc_mt3dusgs, conc_mt3dms, atol=1.5e-3)
     return
 
 

--- a/autotest/t013_test_mt3dms_p10.py
+++ b/autotest/t013_test_mt3dms_p10.py
@@ -163,8 +163,8 @@ def test_mt3dmsp10a():
     mf, mt, conc_mt3dms, cvt, mvt = p10mt3d(exe_name_mf, exe_name_mt3dms,
                                             mt3dms_ws, mixelm)
 
-    msg = 'concentrations not equal {} {}'.format(conc_mt3dusgs, conc_mt3dms)
-    assert  np.allclose(conc_mt3dusgs, conc_mt3dms, atol=1.30e-2), msg
+    np.testing.assert_allclose(conc_mt3dusgs, conc_mt3dms,
+                               rtol=1e-5, atol=1.3e-2)
     return
 
 def test_mt3dmsp10b():  
@@ -179,8 +179,7 @@ def test_mt3dmsp10b():
     mf, mt, conc_mt3dms, cvt, mvt = p10mt3d(exe_name_mf, exe_name_mt3dms,
                                             mt3dms_ws, mixelm)
 
-    msg = 'concentrations not equal {} {}'.format(conc_mt3dusgs, conc_mt3dms)
-    assert  np.allclose(conc_mt3dusgs, conc_mt3dms, atol=1.77), msg
+    np.testing.assert_allclose(conc_mt3dusgs, conc_mt3dms, atol=1.77)
     return
 
 def test_mt3dmsp10c():  
@@ -196,8 +195,7 @@ def test_mt3dmsp10c():
     mf, mt, conc_mt3dms, cvt, mvt = p10mt3d(exe_name_mf, exe_name_mt3dms,
                                             mt3dms_ws, mixelm, ttsmult)
 
-    msg = 'concentrations not equal {} {}'.format(conc_mt3dusgs, conc_mt3dms)
-    assert  np.allclose(conc_mt3dusgs, conc_mt3dms, atol=1.0e-4), msg
+    np.testing.assert_allclose(conc_mt3dusgs, conc_mt3dms, atol=1.0e-4)
     return
 
 

--- a/test-cmp/UZT_NonEq/insert_stopflow_period.py
+++ b/test-cmp/UZT_NonEq/insert_stopflow_period.py
@@ -1,111 +1,56 @@
+'''A script for inserting the stop flow period into the ftl file of the
+non-equilibrium test problem.
+
+The analytical solution was published by Vanderborght et al. (2005) "A set of
+analytical benchmarks to test numerical models of flow and transport in soils"
+The numerical flow solution will still calculate gravity drainage even though
+water is no longer being inserted into the top of the column. To prevent this,
+this script manually overrides the flux terms of the stop flow period to 0.00
+and during this time the dissolved and sorbed phases are equilibrating.
+'''
 import os
-# A script for inserting the stop flow period into the ftl file of the non-equilibrium test problem.
-# The analytical solution was published by Vanderborght et al. (2005) "A set of analytical benchmarks
-# to test numerical models of flow and transport in soils"  The numerical flow solution will still
-# calculate gravity drainage even though water is no longer being inserted into the top of the column.
-# To prevent this, this script manually overrides the flux terms of the stop flow period to 0.00 and
-# during this time the dissolved and sorbed phases are equilibrating.
 
-class switch(object):
-    def __init__(self, value):
-        self.value = value
-        self.fall = False
-    
-    def __iter__(self):
-        """Return the match method once, then stop"""
-        yield self.match
-        raise StopIteration
-    
-    def match(self, *args):
-        """Indicate whether or not to enter a case suite"""
-        if self.fall or not args:
-            return True
-        elif self.value in args: # changed for v1.5, see below
-            self.fall = True
-            return True
-        else:
-            return False
 
-# Define what follows as a function so it is callable by another python script, in this case t003_test.py 
-# on the MT3D-USGS repo
-def InsStpFlw():
+# Define what follows as a function so it is callable by another python script,
+# in this case t003_test.py on the MT3D-USGS repo
+def InsStpFlw(wdir):
     # Read until the beginning of the stop flow period is found
-    srch_str = '           4        '
-
-    sr = open('./temp/NonEq/NonEq.ftl','r')
-    sw = open('./temp/NonEq/NonEq_wStopQ.ftl','w')
-    
     # Start transferring lines until the srch_str is found
-    for line in sr:
-        if len(line) > 16:
-            if srch_str not in line[0:20]:
-                sw.write(line)
-            elif srch_str in line[0:20]:
-    
-                # transfer the current line to the new file
-                sw.write(line)
-    
-                # Peel out next line for looking up in switch
-                line1 = sr.readline()
-                sw.write(line1)
-    
-                # Use switch command to figure out what to do next
-                for case in switch(line1):
-                    if case(" 'QXX             '\n"):
-                        for i in range(126):
-                            line1 = sr.readline()
-                            sw.write('  0.0000000E+00  0.0000000E+00  0.0000000E+00  0.0000000E+00  0.0000000E+00\n')
-    
-                        break
-                    if case(" 'QZZ             '\n"):
-                        for i in range(126):
-                            line1 = sr.readline()
-                            sw.write('  0.0000000E+00  0.0000000E+00  0.0000000E+00  0.0000000E+00  0.0000000E+00\n')
-    
-                        break
-                    if case(" 'STO             '\n"):
-                        for i in range(126):
-                            line1 = sr.readline()
-                            sw.write('  0.0000000E+00  0.0000000E+00  0.0000000E+00  0.0000000E+00  0.0000000E+00\n')
-    
-                        break
-                    if case(" 'CNH             '           5\n"):
+    srch_str = '           4        '
+    with open(os.path.join(wdir, 'NonEq.ftl'), 'r') as sr:
+        with open(os.path.join(wdir, 'NonEq_wStopQ.ftl'), 'w') as sw:
+            while True:
+                line = sr.readline()
+                if not line:
+                    break
+                elif srch_str in line[0:20]:
+                    sw.write(line)
+                    # Peel out next line for looking up in switch
+                    line = sr.readline()
+                    sw.write(line)
+                    label = line.strip().strip("'").strip()
+                    if label in ('QXX', 'QZZ', 'STO', 'UZ FLUX', 'UZQSTO'):
+                        num_items = 0
+                        while num_items < 630:
+                            items = sr.readline().split()
+                            sw.write(len(items) * ' 0.0' + '\n')
+                            num_items += len(items)
+                        assert num_items == 630, num_items
+                    elif label.startswith('CNH'):
                         for i in range(5):
-                            line1 = sr.readline()
-                        sw.write('         209           1           1  0.0000000E+00\n')
-                        sw.write('         209           1           3  0.0000000E+00\n')
-                        sw.write('         210           1           1  0.0000000E+00\n')
-                        sw.write('         210           1           2  0.0000000E+00\n')
-                        sw.write('         210           1           3  0.0000000E+00\n')
-    
-                        break
-                    if case(" 'UZ FLUX         '\n"):
-                        for i in range(126):
-                            line1 = sr.readline()
-                            sw.write('  0.0000000E+00  0.0000000E+00  0.0000000E+00  0.0000000E+00  0.0000000E+00\n')
-    
-                        break
-                    if case(" 'UZQSTO          '\n"):
-                        for i in range(126):
-                            line1 = sr.readline()
-                            sw.write('  0.0000000E+00  0.0000000E+00  0.0000000E+00  0.0000000E+00  0.0000000E+00\n')
-    
-                        break
-                    if case():  # default
-                        line1 = sr.readline()
-                        sw.write(line1)
-                        break
-    
-        else:
-            sw.write(line)
-
-    
-    sr.close()
-    sw.close()
+                            items = sr.readline().split()
+                            assert len(items) == 4, (label, items)
+                        sw.write(' 209 1 1 0.0\n')
+                        sw.write(' 209 1 3 0.0\n')
+                        sw.write(' 210 1 1 0.0\n')
+                        sw.write(' 210 1 2 0.0\n')
+                        sw.write(' 210 1 3 0.0\n')
+                    else:  # other datasets
+                        sw.write(sr.readline())
+                else:
+                    sw.write(line)
 
 
 if __name__ == '__main__':
-    # test1.py executed as script
-    # do something
-    InsStpFlw()
-
+    # executed as script in current directory to process NonEq.ftl
+    InsStpFlw('.')


### PR DESCRIPTION
There are a few testing-related things going on with this PR. First, with Travis CI:
 - Change language from `c` to `python` to take advantage of [built-in features for that language](https://docs.travis-ci.com/user/languages/python/); there is no advantage of using `c` (also `fortran` is not a supported language)
 - Use [xenial build environment](https://docs.travis-ci.com/user/reference/xenial/), because it's modern, same speed and fully supported
 - No such thing as `apt: true` cache
 - Use `FC` environment variable to control gfortran version and symbolic link identified by pymake
 - Replace miniconda with xenial's Python 3.7

And with the Python testing:
 - Replace `assert np.allclose` with `np.testing.assert_allclose`, which provides a nice concise output of differences (if necessary). This required specifying the `rtol=1e-05` in a few places for some tests to behave the same as `np.allclose`.
 - Simplify `UZT_NonEq/insert_stopflow_period.py` to use conventional Python features. It also now works with Python 2.7 (if that's needed)

